### PR TITLE
Use plain https module for post-install script

### DIFF
--- a/generateIconConfig.js
+++ b/generateIconConfig.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var fs = require('fs');
-var req = require('request');
+var https = require('https');
 
 var config = {
     src: path.resolve(
@@ -9,25 +9,44 @@ var config = {
     dest: './icons.json'
 };
 
-req.get('https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/scss/_variables.scss', function (e, d, data) {
-    if (e) console.log(e);
+var varsUrl = 'https://raw.githubusercontent.com/FortAwesome/Font-Awesome/';
+varsUrl += 'master/scss/_variables.scss';
 
-    var lines = data.split('\n').filter(n => {
-        return n !== undefined && n !== '' && n.startsWith('$fa-var-');
-    });
-    var icons = {};
-
-    for (var line of lines) {
-        var icon = line.substring(0, line.indexOf(':')).replace('$fa-var-', '');
-        var code = line.substring(line.indexOf('\\f'), line.indexOf('";'))
-            .replace('\\f', '');
-
-        icons[icon] = code;
+https.request(varsUrl, function (res) {
+    if (res.statusCode !== 200) {
+        throw new Error(
+            'Failed to fetch variables from Github, got HTTP ' + res.statusCode
+        );
     }
 
-    fs.writeFile(config.dest, JSON.stringify(icons), function (error) {
-        if (error) console.log(error);
-
-        console.log('Icons file created');
+    var data = '';
+    res.setEncoding('utf8');
+    res.on('data', function (chunk) {
+        data += chunk;
     });
-});
+
+    res.on('end', function () {
+        var lines = data.split('\n').filter(n => {
+            return n !== undefined && n !== '' && n.startsWith('$fa-var-');
+        });
+        var icons = {};
+
+        for (var line of lines) {
+            var icon = line.substring(0, line.indexOf(':'))
+                    .replace('$fa-var-', '');
+
+            var code = line.substring(line.indexOf('\\f'), line.indexOf('";'))
+                    .replace('\\f', '');
+
+            icons[icon] = code;
+        }
+
+        fs.writeFile(config.dest, JSON.stringify(icons), function (error) {
+            if (error) {
+                throw error;
+            }
+
+            console.log('Icons file created');
+        });
+    });
+}).end();

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "homepage": "https://github.com/dan-gamble/postcss-font-awesome",
   "dependencies": {
-    "postcss": "^5.0.14",
-    "request": "^2.72.0"
+    "postcss": "^5.0.14"
   },
   "devDependencies": {
     "ava": "^0.14.0",


### PR DESCRIPTION
Guess I should have asked before doing this PR, but is there a good reason to generate the icons file post-install over publishing new versions every once in a while? It's sort of confusing when two people can have the same version of this plugin yet have different results based on when they installed it...

I'm trying to install this as part of a larger project, and I'm using [pnpm](https://github.com/rstacruz/pnpm) over regular NPM because I'm going crazy waiting for NPM to finish. It seems that the postinstall step is run before the `request` module has finished pulling down it's dependencies (since it's doing this async), so it crashes. I realize this is a bug on pnpm's part.

Preferably I'd like to see the JSON file as part of the release bundle, not generated post-install. If not, maybe this PR could be considered? It simply uses the built-in `https` module to do the request instead of requiring `request` with all its (many) dependencies.
